### PR TITLE
KTSA-#40 : fix toComboBox().getOptions() not returning any options.

### DIFF
--- a/src/main/java/com/ktsapi/elements/impl/ComboBoxImpl.java
+++ b/src/main/java/com/ktsapi/elements/impl/ComboBoxImpl.java
@@ -55,7 +55,7 @@ public class ComboBoxImpl extends BaseWebElementImpl implements ComboBox{
 		String logMessage = "ComboBox GetOptions of {%s} ";
 		List<WebElement> webElm;
 		try {			
-			webElm = selectElement.getAllSelectedOptions() ;
+			webElm = selectElement.getOptions() ;
 			logMessage = logMessage.concat("returns ").concat(webElm.size() + " WebElement");
 			ActionsLogger.logAction(ActionLog.ActionLogWithReturnValue(ABotActions.ToComboBox_getOptions,getElementLog(parentBaseWebElement,null),null,null,"@List<WebElement>",logMessage));
 			return webElm;


### PR DESCRIPTION
toComboBox().getOptions() also set to return getAllSelectedOptions.
Called correct getOptions().